### PR TITLE
Asset Lists and Asset Create URLs fixed

### DIFF
--- a/src/routes/assetRoutes.ts
+++ b/src/routes/assetRoutes.ts
@@ -10,7 +10,7 @@ const router = Router();
 
 router.get("/", getAllUserAssets);
 
-router.post("/", createUserAsset);
+router.post("/new", createUserAsset);
 
 router.put("/:asset_id/edit", updateUserAsset);
 


### PR DESCRIPTION
Asset Lists and Asset Create URLs fixed:

Having Axios connection issues when loading the asset list component. The solution was to change the Browser Router link from "/assetlist" to "/assets (also changed in the navigation component)